### PR TITLE
Added Mac OS Sierra support, GUI zoom, MIDI through using virtual output (loopMIDI)

### DIFF
--- a/SOMI-1 Editor.jucer
+++ b/SOMI-1 Editor.jucer
@@ -4,7 +4,7 @@
               addUsingNamespaceToJuceHeader="0" jucerFormatVersion="1" companyName="Instruments of Things GmbH"
               companyWebsite="www.instrumentsofthings.com" companyEmail="contact@instrumentsofthings.com"
               cppLanguageStandard="17" bundleIdentifier="com.instrumentsofthings.somi-1-editor"
-              version="0.1.1" companyCopyright="GPLv3">
+              version="0.1.2" companyCopyright="GPLv3">
   <MAINGROUP id="xVsjNm" name="SOMI-1-Editor">
     <GROUP id="{C1DE7F08-3D34-7E82-087A-1180C7F26E80}" name="Source">
       <GROUP id="{6F97294E-11E2-CC9A-D784-7EBCC779DBFA}" name="resources">
@@ -172,14 +172,15 @@
         <MODULEPATH id="juce_gui_extra" path="../../../JUCE/modules"/>
       </MODULEPATHS>
     </XCODE_IPHONE>
-    <XCODE_MAC targetFolder="Builds/MacOSX" applicationCategory="public.app-category.utilities"
+    <XCODE_MAC targetFolder="Builds/MacOSX" applicationCategory="public.app-category.music"
                iosDevelopmentTeamID="CDZ55HPLZS" bigIcon="JUtcgR" hardenedRuntime="1"
-               smallIcon="BESxVF">
+               smallIcon="BESxVF" extraLinkerFlags="-Wl,-weak_reference_mismatches,weak"
+               extraDefs="JUCE_SILENCE_XCODE_15_LINKER_WARNING=1">
       <CONFIGURATIONS>
-        <CONFIGURATION isDebug="1" name="Debug" targetName="SOMI-1 Editor" macOSDeploymentTarget="10.13"
-                       osxCompatibility="10.13 SDK"/>
-        <CONFIGURATION isDebug="0" name="Release" targetName="SOMI-1 Editor" osxCompatibility="10.13 SDK"
-                       macOSDeploymentTarget="10.13"/>
+        <CONFIGURATION isDebug="1" name="Debug" targetName="SOMI-1 Editor" macOSDeploymentTarget="10.12"
+                       osxCompatibility="10.12 SDK"/>
+        <CONFIGURATION isDebug="0" name="Release" targetName="SOMI-1 Editor" osxCompatibility="10.12 SDK"
+                       macOSDeploymentTarget="10.12"/>
       </CONFIGURATIONS>
       <MODULEPATHS>
         <MODULEPATH id="juce_audio_basics" path="../../../JUCE/modules"/>

--- a/SOMI-1 Editor.jucer
+++ b/SOMI-1 Editor.jucer
@@ -49,6 +49,8 @@
       <FILE id="cNJvHI" name="data_types.h" compile="0" resource="0" file="Source/data_types.h"/>
       <FILE id="SG9C3a" name="EditorView.cpp" compile="1" resource="0" file="Source/EditorView.cpp"/>
       <FILE id="GtwoRk" name="EditorView.h" compile="0" resource="0" file="Source/EditorView.h"/>
+      <FILE id="B2AWby" name="InfoComponent.cpp" compile="1" resource="0"
+            file="Source/InfoComponent.cpp"/>
       <FILE id="RpQifF" name="InfoComponent.h" compile="0" resource="0" file="Source/InfoComponent.h"/>
       <FILE id="uQ7ePy" name="Main.cpp" compile="1" resource="0" file="Source/Main.cpp"/>
       <FILE id="ALEWZn" name="MainComponent.cpp" compile="1" resource="0"

--- a/Source/InfoComponent.cpp
+++ b/Source/InfoComponent.cpp
@@ -1,0 +1,136 @@
+/*
+  ==============================================================================
+
+    InfoComponent.cpp
+    Created: 5 Apr 2023 10:26:23am
+    Author:  Henrik
+
+  ==============================================================================
+*/
+
+#include "InfoComponent.h"
+
+#include "MainComponent.h"
+
+InfoComponent::InfoComponent() :
+updateButton("Update", juce::URL(SOMI_URL_UPDATE)),
+manualButton("Manual", juce::URL(SOMI_URL_MANUAL)),
+quickstartButton("Quick Start Guide", juce::URL(SOMI_URL_QUICK_START)),
+supportButton("Support", juce::URL(SOMI_URL_SUPPORT)),
+zoomSlider(juce::Slider::SliderStyle::LinearHorizontal, juce::Slider::TextEntryBoxPosition::NoTextBox)
+{
+    setLookAndFeel(&somiLf);
+
+    closeButton = std::make_unique<juce::DrawableButton>("CloseButton",  juce::DrawableButton::ButtonStyle::ImageFitted);
+    closeButton->setImages(juce::Drawable::createFromImageData(BinaryData::icon_button_close_svg, BinaryData::icon_button_close_svgSize).get());
+    closeButton->addListener(this);
+    addAndMakeVisible(*closeButton);
+
+    addAndMakeVisible(&versionLabel);
+    versionLabel.setText(juce::String("Version: ") + ProjectInfo::versionString, juce::dontSendNotification);
+    int versionFontHeight = juce::Point<int>(0, SomiLookAndFeel::fontSizeBig).getY();
+    juce::Font versionFont(SomiLookAndFeel::getFontInterExtraLight().withHeight(versionFontHeight));
+    versionLabel.setFont(versionFont);
+    versionLabel.setJustificationType(juce::Justification::left);
+    versionLabel.setColour(juce::Label::backgroundColourId, juce::Colours::white.withAlpha(0.5f));
+    
+    infoText.setLookAndFeel(&infoTextLf);
+    infoText.setColour(juce::TextEditor::backgroundColourId, juce::Colours::white.withAlpha(0.5f));
+    infoText.setColour(juce::TextEditor::textColourId, juce::Colours::white.withAlpha(0.5f));
+    infoText.setColour(juce::TextEditor::highlightedTextColourId, juce::Colours::white.withAlpha(0.5f));
+    infoText.setColour(juce::TextEditor::highlightColourId, juce::Colours::white.withAlpha(0.f));
+    
+    // TODO Don't change mouse cursor when hovering over text
+    infoText.setJustification(juce::Justification::topLeft);
+    infoText.setMultiLine(true);
+    infoText.setReadOnly(true);
+    infoText.setBorder(juce::BorderSize<int>(0));
+    int infoFontHeight = juce::Point<int>(0, SomiLookAndFeel::fontSizeSmall).getY();
+    juce::Font infoFont(SomiLookAndFeel::getFontInterExtraLight().withHeight(infoFontHeight));
+    infoText.setFont(infoFont);
+    infoText.setText("v" + juce::String(ProjectInfo::versionString) + "\n" + juce::String(juce::CharPointer_UTF8(SOMI_EDITOR_INFO_TEXT)), juce::dontSendNotification);
+    addAndMakeVisible(&infoText);
+    
+    addAndMakeVisible(&updateButton);
+    addAndMakeVisible(&manualButton);
+    addAndMakeVisible(&quickstartButton);
+    addAndMakeVisible(&supportButton);
+    
+    addAndMakeVisible(&zoomSlider);
+    zoomSlider.setRange(50.0, 150.0);
+    zoomSlider.setTextValueSuffix(" %");
+    zoomSlider.setValue(100.0);
+    zoomSlider.setColour(juce::Slider::thumbColourId, juce::Colours::white);
+    
+    addAndMakeVisible(&zoomLabel);
+    zoomLabel.setFont(versionFont);
+    zoomLabel.setText("Zoom", juce::dontSendNotification);
+    zoomLabel.attachToComponent(&zoomSlider, true);
+    zoomLabel.setColour(juce::Label::textColourId, juce::Colours::white);
+    zoomLabel.setBorderSize(juce::BorderSize<int>(0));
+    
+    
+    zoomSlider.onValueChange = [this]{
+        
+        auto physicalDim = juce::Rectangle<float>(0, 0, 1915, 1320); // Took from design template
+        
+        const float scaleFactor = (1280.0 / physicalDim.getWidth()) * zoomSlider.getValue() / 100.0;
+        juce::Desktop::getInstance().setGlobalScaleFactor(scaleFactor);
+        
+        auto mainComponent = findParentComponentOfClass<MainComponent>();
+        jassert(mainComponent != nullptr);
+        
+        mainComponent->setSize(physicalDim.getWidth(), physicalDim.getHeight());
+    };
+}
+
+InfoComponent::~InfoComponent()
+{
+    setLookAndFeel(nullptr);
+    
+    closeButton->removeListener(this);
+}
+
+void InfoComponent::paint (juce::Graphics& g)
+{
+    g.fillAll(juce::Colours::black);
+}
+
+void InfoComponent::resized()
+{
+    int offset = 22;
+    int xStart = 70 - offset;
+    
+    closeButton->setBounds(juce::Rectangle<int>(609-64, 49-offset, 48, 48));
+    
+    versionLabel.setBounds(juce::Rectangle<int>(xStart, 49-offset, 300, SomiLookAndFeel::fontSizeBig));
+    
+    infoText.setBounds(juce::Rectangle<int>(xStart, 983-offset, 609-70, 14*19));
+    
+    auto logicalFontHeight = juce::Point<float>(0, SomiLookAndFeel::fontSizeBig).getY();
+    juce::Font font(SomiLookAndFeel::getFontInterExtraLight().withHeight(logicalFontHeight));
+    
+    updateButton.setBounds(juce::Rectangle<int>(xStart, 157-offset, 600, SomiLookAndFeel::fontSizeBig));
+    font.setUnderline(true);
+    updateButton.setFont(font, false, juce::Justification::topLeft);
+    updateButton.changeWidthToFitText();
+
+    manualButton.setBounds(juce::Rectangle<int>(xStart, 248-offset, 600, SomiLookAndFeel::fontSizeBig));
+    manualButton.setFont(font, false, juce::Justification::topLeft);
+    manualButton.changeWidthToFitText();
+    
+    quickstartButton.setBounds(juce::Rectangle<int>(xStart, 339-offset, 600, SomiLookAndFeel::fontSizeBig));
+    quickstartButton.setFont(font, false, juce::Justification::topLeft);
+    quickstartButton.changeWidthToFitText();
+    
+    supportButton.setBounds(juce::Rectangle<int>(xStart, 430-offset, 600, SomiLookAndFeel::fontSizeBig));
+    supportButton.setFont(font, false, juce::Justification::topLeft);
+    supportButton.changeWidthToFitText();
+    
+    int versionFontHeight = juce::Point<int>(0, SomiLookAndFeel::fontSizeBig).getY();
+    juce::Font versionFont(SomiLookAndFeel::getFontInterExtraLight().withHeight(versionFontHeight));
+    
+    int zoomLabelWidth = versionFont.getStringWidth(zoomLabel.getText());
+    
+    zoomSlider.setBounds(xStart+zoomLabelWidth, supportButton.getY() + supportButton.getHeight() + 60, getWidth()-2*xStart-zoomLabelWidth, SomiLookAndFeel::fontSizeBig);
+}

--- a/Source/InfoComponent.h
+++ b/Source/InfoComponent.h
@@ -21,93 +21,11 @@ class InfoComponent : public juce::Component,
                       public juce::Button::Listener
 {
 public:
-    InfoComponent()
-    : updateButton("Update", juce::URL(SOMI_URL_UPDATE)),
-      manualButton("Manual", juce::URL(SOMI_URL_MANUAL)),
-      quickstartButton("Quick Start Guide", juce::URL(SOMI_URL_QUICK_START)),
-      supportButton("Support", juce::URL(SOMI_URL_SUPPORT))
-    {
-        setLookAndFeel(&somiLf);
+    InfoComponent();
+    ~InfoComponent() override;
 
-        closeButton = std::make_unique<juce::DrawableButton>("CloseButton",  juce::DrawableButton::ButtonStyle::ImageFitted);
-        closeButton->setImages(juce::Drawable::createFromImageData(BinaryData::icon_button_close_svg, BinaryData::icon_button_close_svgSize).get());
-        closeButton->addListener(this);
-        addAndMakeVisible(*closeButton);
-
-        addAndMakeVisible(&versionLabel);
-        versionLabel.setText(juce::String("Version: ") + ProjectInfo::versionString, juce::dontSendNotification);
-        int versionFontHeight = juce::Point<int>(0, SomiLookAndFeel::fontSizeBig).getY();
-        juce::Font versionFont(SomiLookAndFeel::getFontInterExtraLight().withHeight(versionFontHeight));
-        versionLabel.setFont(versionFont);
-        versionLabel.setJustificationType(juce::Justification::left);
-        versionLabel.setColour(juce::Label::backgroundColourId, juce::Colours::white.withAlpha(0.5f));
-        
-        infoText.setLookAndFeel(&infoTextLf);
-        infoText.setColour(juce::TextEditor::backgroundColourId, juce::Colours::white.withAlpha(0.5f));
-        infoText.setColour(juce::TextEditor::textColourId, juce::Colours::white.withAlpha(0.5f));
-        infoText.setColour(juce::TextEditor::highlightedTextColourId, juce::Colours::white.withAlpha(0.5f));
-        infoText.setColour(juce::TextEditor::highlightColourId, juce::Colours::white.withAlpha(0.f));
-        
-        // TODO Don't change mouse cursor when hovering over text
-        infoText.setJustification(juce::Justification::topLeft);
-        infoText.setMultiLine(true);
-        infoText.setReadOnly(true);
-        infoText.setBorder(juce::BorderSize<int>(0));
-        int infoFontHeight = juce::Point<int>(0, SomiLookAndFeel::fontSizeSmall).getY();
-        juce::Font infoFont(SomiLookAndFeel::getFontInterExtraLight().withHeight(infoFontHeight));
-        infoText.setFont(infoFont);
-        infoText.setText("v" + juce::String(ProjectInfo::versionString) + "\n" + juce::String(juce::CharPointer_UTF8(SOMI_EDITOR_INFO_TEXT)), juce::dontSendNotification);
-        addAndMakeVisible(&infoText);
-        
-        addAndMakeVisible(&updateButton);
-        addAndMakeVisible(&manualButton);
-        addAndMakeVisible(&quickstartButton);
-        addAndMakeVisible(&supportButton);
-    }
-
-    ~InfoComponent() override
-    {
-        setLookAndFeel(nullptr);
-        
-        closeButton->removeListener(this);
-    }
-
-    void paint (juce::Graphics& g) override
-    {
-        g.fillAll(juce::Colours::black);
-    }
-
-    void resized() override
-    {
-        int offset = 22;
-        int xStart = 70 - offset;
-        
-        closeButton->setBounds(juce::Rectangle<int>(609-64, 49-offset, 48, 48));
-        
-        versionLabel.setBounds(juce::Rectangle<int>(xStart, 49-offset, 300, SomiLookAndFeel::fontSizeBig));
-        
-        infoText.setBounds(juce::Rectangle<int>(xStart, 983-offset, 609-70, 14*19));
-        
-        auto logicalFontHeight = juce::Point<float>(0, SomiLookAndFeel::fontSizeBig).getY();
-        juce::Font font(SomiLookAndFeel::getFontInterExtraLight().withHeight(logicalFontHeight));
-        
-        updateButton.setBounds(juce::Rectangle<int>(xStart, 157-offset, 600, SomiLookAndFeel::fontSizeBig));
-        font.setUnderline(true);
-        updateButton.setFont(font, false, juce::Justification::topLeft);
-        updateButton.changeWidthToFitText();
-
-        manualButton.setBounds(juce::Rectangle<int>(xStart, 248-offset, 600, SomiLookAndFeel::fontSizeBig));
-        manualButton.setFont(font, false, juce::Justification::topLeft);
-        manualButton.changeWidthToFitText();
-        
-        quickstartButton.setBounds(juce::Rectangle<int>(xStart, 339-offset, 600, SomiLookAndFeel::fontSizeBig));
-        quickstartButton.setFont(font, false, juce::Justification::topLeft);
-        quickstartButton.changeWidthToFitText();
-        
-        supportButton.setBounds(juce::Rectangle<int>(xStart, 430-offset, 600, SomiLookAndFeel::fontSizeBig));
-        supportButton.setFont(font, false, juce::Justification::topLeft);
-        supportButton.changeWidthToFitText();
-    }
+    void paint (juce::Graphics& g) override;
+    void resized() override;
     
     void mouseDown(const juce::MouseEvent& event) override
     {
@@ -133,6 +51,9 @@ private:
                           manualButton,
                           quickstartButton,
                           supportButton;
-
+    
+    juce::Label zoomLabel;
+    juce::Slider zoomSlider;
+    
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (InfoComponent)
 };

--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -12,8 +12,12 @@
 
 //==============================================================================
 MainComponent::MainComponent()
-: virtualMidiOutInitialized(false), somiMidiIoInitialized(false), dataModel(), editorView(dataModel)
-{  
+: 
+#if JUCE_WINDOWS
+    virtualMidiOutInitialized(false),
+#endif
+    somiMidiIoInitialized(false), dataModel(), editorView(dataModel)
+{
     auto physicalDim = juce::Rectangle<float>(0, 0, 1915, 1320); // Took from design template
 
 #if JUCE_MAC

--- a/Source/MainComponent.h
+++ b/Source/MainComponent.h
@@ -48,6 +48,10 @@ private:
     void handleIncomingMidiMessage(juce::MidiInput* source, const juce::MidiMessage& message) override;
     void timerCallback() override;
     
+#if JUCE_WINDOWS
+    bool virtualMidiOutInitialized;
+    std::unique_ptr<juce::MidiOutput> virtualMidiOutput;
+#endif
     std::unique_ptr<juce::MidiOutput> midiOutput;
     bool somiMidiIoInitialized;
     juce::Array<juce::MidiDeviceInfo> midiInputs;


### PR DESCRIPTION
- Added support for Mac OS Sierra
- Added zoom slider to info screen
- MIDI data is forwarded to virtual output port on Windows as default MIDI driver does not support concurrent access by multiple applications. [loopMIDI](https://www.tobias-erichsen.de/software/loopmidi.html) is required (free). 